### PR TITLE
fix(session): guard Release against nil sessionInfo

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -155,22 +155,21 @@ func (t *tgmSessionPool) Get(ctx context.Context, serviceName string, organizati
 func (t *tgmSessionPool) Release(sessionKey string) {
 	go func() {
 		t.sessionsMutex.Lock()
-		defer t.sessionsMutex.Unlock()
-
 		sessionInfo := t.sessions[sessionKey]
-		sessionInfo.mutex.Lock()
-		defer sessionInfo.mutex.Unlock()
 
 		// Collect all workers to release and close the session
 		var workersToRelease []string
 		var done chan struct{}
 		if sessionInfo != nil {
+			sessionInfo.mutex.Lock()
 			for workerKey := range sessionInfo.workers {
 				workersToRelease = append(workersToRelease, workerKey)
 			}
 			done = sessionInfo.closer
 			delete(t.sessions, sessionKey)
+			sessionInfo.mutex.Unlock()
 		}
+		t.sessionsMutex.Unlock()
 
 		// Close the done channel after releasing the lock
 		if done != nil {


### PR DESCRIPTION
## Summary
- Fixes a `nil pointer dereference` panic in `tgmSessionPool.Release` when `sessionKey` is not present in the `sessions` map (e.g. the session was never inserted because `BorrowWorker` returned a non-`borrowed` status, or a concurrent `Release` already removed it).
- The map lookup was followed unconditionally by `sessionInfo.mutex.Lock()`, with the `if sessionInfo != nil` guard appearing after the deref — unreachable when nil.
- Moves the mutex acquisition inside the nil check, and releases `sessionsMutex` once local cleanup is done so the global lock is no longer held across the remote `ReturnWorker` gRPC call.

Stack from the reporter:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x40 pc=0x2becad1]
sync.(*Mutex).Lock(...)
github.com/streamingfast/payment-gateway/session.(*tgmSessionPool).Release.func1()
        session/session.go:159
created by github.com/streamingfast/payment-gateway/session.(*tgmSessionPool).Release
        session/session.go:156
```